### PR TITLE
Fix tests that broke due to `black` and optimize GH Actions

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -4,7 +4,6 @@ on:
   push:
     # tags:
     #   - '*.*.*'
-    # 
 jobs:
   test-changelog:
     runs-on: ubuntu-latest
@@ -124,182 +123,200 @@ jobs:
           export HOST_UID=$(id -u)
           docker load < "image-pharus-${PHARUS_VERSION}-py${PY_VER}-${DISTRO}.tar.gz"
           docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
-  # publish-release:
-  #   if: github.event_name == 'push'
-  #   needs: test
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     TWINE_USERNAME: ${{secrets.twine_username}}
-  #     TWINE_PASSWORD: ${{secrets.twine_password}}
-  #   outputs:
-  #     release_upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Determine package version
-  #       run: |
-  #         PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
-  #         echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
-  #     - name: Get changelog entry
-  #       id: changelog_reader
-  #       uses: guzman-raphael/changelog-reader-action@v5
-  #       with:
-  #         path: ./CHANGELOG.md
-  #         version: ${{env.PHARUS_VERSION}}
-  #     - name: Create GH release
-  #       id: create_gh_release
-  #       uses: actions/create-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  #       with:
-  #         tag_name: ${{steps.changelog_reader.outputs.version}}
-  #         release_name: Release ${{steps.changelog_reader.outputs.version}}
-  #         body: ${{steps.changelog_reader.outputs.changes}}
-  #         prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}
-  #         draft: ${{steps.changelog_reader.outputs.status == 'unreleased'}}
-  #     - name: Fetch image artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: image-pharus-${{env.PHARUS_VERSION}}-py3.8-alpine
-  #     - name: Fetch pip artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: pip-pharus-${{env.PHARUS_VERSION}}
-  #         path: dist
-  #     - name: Publish pip release
-  #       run: |
-  #         export HOST_UID=$(id -u)
-  #         docker load < "image-pharus-${PHARUS_VERSION}-py3.8-alpine.tar.gz"
-  #         docker-compose -f docker-compose-build.yaml run \
-  #           -e TWINE_USERNAME=${TWINE_USERNAME} -e TWINE_PASSWORD=${TWINE_PASSWORD} pharus \
-  #           sh -lc "pip install twine && python -m twine upload dist/*"
-  #     - name: Determine pip artifact paths
-  #       run: |
-  #         echo "PHARUS_WHEEL_PATH=$(ls dist/pharus-*.whl)" >> $GITHUB_ENV
-  #         echo "PHARUS_SDIST_PATH=$(ls dist/pharus-*.tar.gz)" >> $GITHUB_ENV
-  #     - name: Upload pip wheel asset to release
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  #       with:
-  #         upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-  #         asset_path: ${{env.PHARUS_WHEEL_PATH}}
-  #         asset_name: pip-pharus-${{env.PHARUS_VERSION}}.whl
-  #         asset_content_type: application/zip
-  #     - name: Upload pip sdist asset to release
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  #       with:
-  #         upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-  #         asset_path: ${{env.PHARUS_SDIST_PATH}}
-  #         asset_name: pip-pharus-${{env.PHARUS_VERSION}}.tar.gz
-  #         asset_content_type: application/gzip
-  #     - name: Upload deploy docker environment
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  #       with:
-  #         upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-  #         asset_path: docker-compose-deploy.yaml
-  #         asset_name: docker-compose-deploy.yaml
-  #         asset_content_type: application/yaml
-  # publish-images:
-  #   if: github.event_name == 'push'
-  #   needs: publish-release
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - py_ver: 3.8
-  #           distro: alpine
-  #           image: djbase
-  #   env:
-  #     PY_VER: ${{matrix.py_ver}}
-  #     DISTRO: ${{matrix.distro}}
-  #     IMAGE: ${{matrix.image}}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Determine package version
-  #       run: |
-  #         PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
-  #         echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
-  #     - name: Fetch image artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-${{matrix.distro}}
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v1
-  #       with:
-  #         username: ${{secrets.docker_username}}
-  #         password: ${{secrets.docker_password}}
-  #     - name: Publish image
-  #       run: |
-  #         docker load < "image-pharus-${PHARUS_VERSION}-py${PY_VER}-${DISTRO}.tar.gz"
-  #         IMAGE=$(docker images --filter "reference=datajoint/*" --format "{{.Repository}}")
-  #         TAG=$(docker images --filter "reference=datajoint/*" --format "{{.Tag}}")
-  #         docker push "${IMAGE}:${TAG}"
-  #         docker tag "${IMAGE}:${TAG}" "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
-  #         docker push "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
-  #         [ "$PY_VER" == "3.8" ] && [ "$DISTRO" == "alpine" ] \
-  #                 && docker tag "${IMAGE}:${TAG}" "${IMAGE}:latest" \
-  #                 && docker push "${IMAGE}:latest" \
-  #             || echo "skipping 'latest' tag..."
-  #     - name: Upload image to release
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  #       with:
-  #         upload_url: ${{needs.publish-release.outputs.release_upload_url}}
-  #         asset_path: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
-  #           ${{matrix.distro}}.tar.gz"
-  #         asset_name: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
-  #           ${{matrix.distro}}.tar.gz"
-  #         asset_content_type: application/gzip
-  # publish-docs:
-  #   if: github.event_name == 'push'
-  #   needs: publish-release
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Determine package version
-  #       run: |
-  #         PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
-  #         echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
-  #     - name: Fetch docs static artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: docs-static-pharus-${{env.PHARUS_VERSION}}
-  #         path: docs/_build/html
-  #     - name: Commit documentation changes
-  #       run: |
-  #         git clone https://github.com/${GITHUB_REPOSITORY}.git \
-  #             --branch gh-pages --single-branch gh-pages
-  #         rm -R gh-pages/*
-  #         cp -r docs/_build/html/* gh-pages/
-  #         cp .gitignore gh-pages/
-  #         touch gh-pages/.nojekyll
-  #         cd gh-pages
-  #         git config --local user.email "action@github.com"
-  #         git config --local user.name "GitHub Action"
-  #         git add . --all
-  #         git commit -m "Update documentation" -a || true
-  #         # The above command will fail if no changes were present, so we ignore
-  #         # the return code.
-  #     - name: Push changes
-  #       uses: ad-m/github-push-action@master
-  #       with:
-  #         branch: gh-pages
-  #         directory: gh-pages
-  #         github_token: ${{secrets.GITHUB_TOKEN}}
-  #     - name: Compress docs static site artifacts
-  #       run: zip -r docs-static-pharus-${PHARUS_VERSION}.zip docs/_build/html
-  #     - name: Upload docs static site to release
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  #       with:
-  #         upload_url: ${{needs.publish-release.outputs.release_upload_url}}
-  #         asset_path: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
-  #         asset_name: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
-  #         asset_content_type: application/zip
-  #         # fail_on_unmatched_files: true
+  publish-release:
+    if: |
+      github.event_name == 'push' &&
+      contains(github.ref, 'refs/tags/*.*.*') &&
+      (
+        github.repository_owner == 'datajoint' ||
+        github.repository_owner == 'vathes'
+      )
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      TWINE_USERNAME: ${{secrets.twine_username}}
+      TWINE_PASSWORD: ${{secrets.twine_password}}
+    outputs:
+      release_upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine package version
+        run: |
+          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
+          echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
+      - name: Get changelog entry
+        id: changelog_reader
+        uses: guzman-raphael/changelog-reader-action@v5
+        with:
+          path: ./CHANGELOG.md
+          version: ${{env.PHARUS_VERSION}}
+      - name: Create GH release
+        id: create_gh_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          tag_name: ${{steps.changelog_reader.outputs.version}}
+          release_name: Release ${{steps.changelog_reader.outputs.version}}
+          body: ${{steps.changelog_reader.outputs.changes}}
+          prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}
+          draft: ${{steps.changelog_reader.outputs.status == 'unreleased'}}
+      - name: Fetch image artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: image-pharus-${{env.PHARUS_VERSION}}-py3.8-alpine
+      - name: Fetch pip artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: pip-pharus-${{env.PHARUS_VERSION}}
+          path: dist
+      - name: Publish pip release
+        run: |
+          export HOST_UID=$(id -u)
+          docker load < "image-pharus-${PHARUS_VERSION}-py3.8-alpine.tar.gz"
+          docker-compose -f docker-compose-build.yaml run \
+            -e TWINE_USERNAME=${TWINE_USERNAME} -e TWINE_PASSWORD=${TWINE_PASSWORD} pharus \
+            sh -lc "pip install twine && python -m twine upload dist/*"
+      - name: Determine pip artifact paths
+        run: |
+          echo "PHARUS_WHEEL_PATH=$(ls dist/pharus-*.whl)" >> $GITHUB_ENV
+          echo "PHARUS_SDIST_PATH=$(ls dist/pharus-*.tar.gz)" >> $GITHUB_ENV
+      - name: Upload pip wheel asset to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+          asset_path: ${{env.PHARUS_WHEEL_PATH}}
+          asset_name: pip-pharus-${{env.PHARUS_VERSION}}.whl
+          asset_content_type: application/zip
+      - name: Upload pip sdist asset to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+          asset_path: ${{env.PHARUS_SDIST_PATH}}
+          asset_name: pip-pharus-${{env.PHARUS_VERSION}}.tar.gz
+          asset_content_type: application/gzip
+      - name: Upload deploy docker environment
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+          asset_path: docker-compose-deploy.yaml
+          asset_name: docker-compose-deploy.yaml
+          asset_content_type: application/yaml
+  publish-images:
+    if: |
+      github.event_name == 'push' &&
+      contains(github.ref, 'refs/tags/*.*.*') &&
+      (
+        github.repository_owner == 'datajoint' ||
+        github.repository_owner == 'vathes'
+      )
+    needs: publish-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - py_ver: 3.8
+            distro: alpine
+            image: djbase
+    env:
+      PY_VER: ${{matrix.py_ver}}
+      DISTRO: ${{matrix.distro}}
+      IMAGE: ${{matrix.image}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine package version
+        run: |
+          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
+          echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
+      - name: Fetch image artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-${{matrix.distro}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{secrets.docker_username}}
+          password: ${{secrets.docker_password}}
+      - name: Publish image
+        run: |
+          docker load < "image-pharus-${PHARUS_VERSION}-py${PY_VER}-${DISTRO}.tar.gz"
+          IMAGE=$(docker images --filter "reference=datajoint/*" --format "{{.Repository}}")
+          TAG=$(docker images --filter "reference=datajoint/*" --format "{{.Tag}}")
+          docker push "${IMAGE}:${TAG}"
+          docker tag "${IMAGE}:${TAG}" "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
+          docker push "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
+          [ "$PY_VER" == "3.8" ] && [ "$DISTRO" == "alpine" ] \
+                  && docker tag "${IMAGE}:${TAG}" "${IMAGE}:latest" \
+                  && docker push "${IMAGE}:latest" \
+              || echo "skipping 'latest' tag..."
+      - name: Upload image to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          upload_url: ${{needs.publish-release.outputs.release_upload_url}}
+          asset_path: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
+            ${{matrix.distro}}.tar.gz"
+          asset_name: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
+            ${{matrix.distro}}.tar.gz"
+          asset_content_type: application/gzip
+  publish-docs:
+    if: |
+      github.event_name == 'push' &&
+      contains(github.ref, 'refs/tags/*.*.*') &&
+      (
+        github.repository_owner == 'datajoint' ||
+        github.repository_owner == 'vathes'
+      )
+    needs: publish-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine package version
+        run: |
+          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
+          echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
+      - name: Fetch docs static artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: docs-static-pharus-${{env.PHARUS_VERSION}}
+          path: docs/_build/html
+      - name: Commit documentation changes
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY}.git \
+              --branch gh-pages --single-branch gh-pages
+          rm -R gh-pages/*
+          cp -r docs/_build/html/* gh-pages/
+          cp .gitignore gh-pages/
+          touch gh-pages/.nojekyll
+          cd gh-pages
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add . --all
+          git commit -m "Update documentation" -a || true
+          # The above command will fail if no changes were present, so we ignore
+          # the return code.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{secrets.GITHUB_TOKEN}}
+      - name: Compress docs static site artifacts
+        run: zip -r docs-static-pharus-${PHARUS_VERSION}.zip docs/_build/html
+      - name: Upload docs static site to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          upload_url: ${{needs.publish-release.outputs.release_upload_url}}
+          asset_path: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
+          asset_name: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
+          asset_content_type: application/zip
+          # fail_on_unmatched_files: true

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -4,6 +4,7 @@ on:
   push:
     # tags:
     #   - '*.*.*'
+    # 
 jobs:
   test-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -2,8 +2,6 @@ name: Development
 on:
   pull_request:
   push:
-    # tags:
-    #   - '*.*.*'
 jobs:
   test-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -2,8 +2,8 @@ name: Development
 on:
   pull_request:
   push:
-    tags:
-      - '*.*.*'
+    # tags:
+    #   - '*.*.*'
 jobs:
   test-changelog:
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Compile docs static artifacts
         run: |
-          export PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}')
+          export PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
           export HOST_UID=$(id -u)
           docker-compose -f docker-compose-docs.yaml up --exit-code-from pharus-docs --build
           echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Compile image
         run: |
-          export PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}')
+          export PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
           export HOST_UID=$(id -u)
           docker-compose -f docker-compose-build.yaml up --exit-code-from pharus --build
           IMAGE=$(docker images --filter "reference=datajoint/pharus*" \
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Determine package version
         run: |
-          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}')
+          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
           echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
       - name: Fetch image artifact
         uses: actions/download-artifact@v2
@@ -123,182 +123,182 @@ jobs:
           export HOST_UID=$(id -u)
           docker load < "image-pharus-${PHARUS_VERSION}-py${PY_VER}-${DISTRO}.tar.gz"
           docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
-  publish-release:
-    if: github.event_name == 'push'
-    needs: test
-    runs-on: ubuntu-latest
-    env:
-      TWINE_USERNAME: ${{secrets.twine_username}}
-      TWINE_PASSWORD: ${{secrets.twine_password}}
-    outputs:
-      release_upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Determine package version
-        run: |
-          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}')
-          echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
-      - name: Get changelog entry
-        id: changelog_reader
-        uses: guzman-raphael/changelog-reader-action@v5
-        with:
-          path: ./CHANGELOG.md
-          version: ${{env.PHARUS_VERSION}}
-      - name: Create GH release
-        id: create_gh_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          tag_name: ${{steps.changelog_reader.outputs.version}}
-          release_name: Release ${{steps.changelog_reader.outputs.version}}
-          body: ${{steps.changelog_reader.outputs.changes}}
-          prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}
-          draft: ${{steps.changelog_reader.outputs.status == 'unreleased'}}
-      - name: Fetch image artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: image-pharus-${{env.PHARUS_VERSION}}-py3.8-alpine
-      - name: Fetch pip artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: pip-pharus-${{env.PHARUS_VERSION}}
-          path: dist
-      - name: Publish pip release
-        run: |
-          export HOST_UID=$(id -u)
-          docker load < "image-pharus-${PHARUS_VERSION}-py3.8-alpine.tar.gz"
-          docker-compose -f docker-compose-build.yaml run \
-            -e TWINE_USERNAME=${TWINE_USERNAME} -e TWINE_PASSWORD=${TWINE_PASSWORD} pharus \
-            sh -lc "pip install twine && python -m twine upload dist/*"
-      - name: Determine pip artifact paths
-        run: |
-          echo "PHARUS_WHEEL_PATH=$(ls dist/pharus-*.whl)" >> $GITHUB_ENV
-          echo "PHARUS_SDIST_PATH=$(ls dist/pharus-*.tar.gz)" >> $GITHUB_ENV
-      - name: Upload pip wheel asset to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-          asset_path: ${{env.PHARUS_WHEEL_PATH}}
-          asset_name: pip-pharus-${{env.PHARUS_VERSION}}.whl
-          asset_content_type: application/zip
-      - name: Upload pip sdist asset to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-          asset_path: ${{env.PHARUS_SDIST_PATH}}
-          asset_name: pip-pharus-${{env.PHARUS_VERSION}}.tar.gz
-          asset_content_type: application/gzip
-      - name: Upload deploy docker environment
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          upload_url: ${{steps.create_gh_release.outputs.upload_url}}
-          asset_path: docker-compose-deploy.yaml
-          asset_name: docker-compose-deploy.yaml
-          asset_content_type: application/yaml
-  publish-images:
-    if: github.event_name == 'push'
-    needs: publish-release
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - py_ver: 3.8
-            distro: alpine
-            image: djbase
-    env:
-      PY_VER: ${{matrix.py_ver}}
-      DISTRO: ${{matrix.distro}}
-      IMAGE: ${{matrix.image}}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Determine package version
-        run: |
-          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}')
-          echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
-      - name: Fetch image artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-${{matrix.distro}}
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{secrets.docker_username}}
-          password: ${{secrets.docker_password}}
-      - name: Publish image
-        run: |
-          docker load < "image-pharus-${PHARUS_VERSION}-py${PY_VER}-${DISTRO}.tar.gz"
-          IMAGE=$(docker images --filter "reference=datajoint/*" --format "{{.Repository}}")
-          TAG=$(docker images --filter "reference=datajoint/*" --format "{{.Tag}}")
-          docker push "${IMAGE}:${TAG}"
-          docker tag "${IMAGE}:${TAG}" "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
-          docker push "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
-          [ "$PY_VER" == "3.8" ] && [ "$DISTRO" == "alpine" ] \
-                  && docker tag "${IMAGE}:${TAG}" "${IMAGE}:latest" \
-                  && docker push "${IMAGE}:latest" \
-              || echo "skipping 'latest' tag..."
-      - name: Upload image to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          upload_url: ${{needs.publish-release.outputs.release_upload_url}}
-          asset_path: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
-            ${{matrix.distro}}.tar.gz"
-          asset_name: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
-            ${{matrix.distro}}.tar.gz"
-          asset_content_type: application/gzip
-  publish-docs:
-    if: github.event_name == 'push'
-    needs: publish-release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Determine package version
-        run: |
-          PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}')
-          echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
-      - name: Fetch docs static artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: docs-static-pharus-${{env.PHARUS_VERSION}}
-          path: docs/_build/html
-      - name: Commit documentation changes
-        run: |
-          git clone https://github.com/${GITHUB_REPOSITORY}.git \
-              --branch gh-pages --single-branch gh-pages
-          rm -R gh-pages/*
-          cp -r docs/_build/html/* gh-pages/
-          cp .gitignore gh-pages/
-          touch gh-pages/.nojekyll
-          cd gh-pages
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add . --all
-          git commit -m "Update documentation" -a || true
-          # The above command will fail if no changes were present, so we ignore
-          # the return code.
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          branch: gh-pages
-          directory: gh-pages
-          github_token: ${{secrets.GITHUB_TOKEN}}
-      - name: Compress docs static site artifacts
-        run: zip -r docs-static-pharus-${PHARUS_VERSION}.zip docs/_build/html
-      - name: Upload docs static site to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          upload_url: ${{needs.publish-release.outputs.release_upload_url}}
-          asset_path: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
-          asset_name: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
-          asset_content_type: application/zip
-          # fail_on_unmatched_files: true
+  # publish-release:
+  #   if: github.event_name == 'push'
+  #   needs: test
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     TWINE_USERNAME: ${{secrets.twine_username}}
+  #     TWINE_PASSWORD: ${{secrets.twine_password}}
+  #   outputs:
+  #     release_upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Determine package version
+  #       run: |
+  #         PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
+  #         echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
+  #     - name: Get changelog entry
+  #       id: changelog_reader
+  #       uses: guzman-raphael/changelog-reader-action@v5
+  #       with:
+  #         path: ./CHANGELOG.md
+  #         version: ${{env.PHARUS_VERSION}}
+  #     - name: Create GH release
+  #       id: create_gh_release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #       with:
+  #         tag_name: ${{steps.changelog_reader.outputs.version}}
+  #         release_name: Release ${{steps.changelog_reader.outputs.version}}
+  #         body: ${{steps.changelog_reader.outputs.changes}}
+  #         prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}
+  #         draft: ${{steps.changelog_reader.outputs.status == 'unreleased'}}
+  #     - name: Fetch image artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: image-pharus-${{env.PHARUS_VERSION}}-py3.8-alpine
+  #     - name: Fetch pip artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: pip-pharus-${{env.PHARUS_VERSION}}
+  #         path: dist
+  #     - name: Publish pip release
+  #       run: |
+  #         export HOST_UID=$(id -u)
+  #         docker load < "image-pharus-${PHARUS_VERSION}-py3.8-alpine.tar.gz"
+  #         docker-compose -f docker-compose-build.yaml run \
+  #           -e TWINE_USERNAME=${TWINE_USERNAME} -e TWINE_PASSWORD=${TWINE_PASSWORD} pharus \
+  #           sh -lc "pip install twine && python -m twine upload dist/*"
+  #     - name: Determine pip artifact paths
+  #       run: |
+  #         echo "PHARUS_WHEEL_PATH=$(ls dist/pharus-*.whl)" >> $GITHUB_ENV
+  #         echo "PHARUS_SDIST_PATH=$(ls dist/pharus-*.tar.gz)" >> $GITHUB_ENV
+  #     - name: Upload pip wheel asset to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #       with:
+  #         upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+  #         asset_path: ${{env.PHARUS_WHEEL_PATH}}
+  #         asset_name: pip-pharus-${{env.PHARUS_VERSION}}.whl
+  #         asset_content_type: application/zip
+  #     - name: Upload pip sdist asset to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #       with:
+  #         upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+  #         asset_path: ${{env.PHARUS_SDIST_PATH}}
+  #         asset_name: pip-pharus-${{env.PHARUS_VERSION}}.tar.gz
+  #         asset_content_type: application/gzip
+  #     - name: Upload deploy docker environment
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #       with:
+  #         upload_url: ${{steps.create_gh_release.outputs.upload_url}}
+  #         asset_path: docker-compose-deploy.yaml
+  #         asset_name: docker-compose-deploy.yaml
+  #         asset_content_type: application/yaml
+  # publish-images:
+  #   if: github.event_name == 'push'
+  #   needs: publish-release
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - py_ver: 3.8
+  #           distro: alpine
+  #           image: djbase
+  #   env:
+  #     PY_VER: ${{matrix.py_ver}}
+  #     DISTRO: ${{matrix.distro}}
+  #     IMAGE: ${{matrix.image}}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Determine package version
+  #       run: |
+  #         PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
+  #         echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
+  #     - name: Fetch image artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-${{matrix.distro}}
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v1
+  #       with:
+  #         username: ${{secrets.docker_username}}
+  #         password: ${{secrets.docker_password}}
+  #     - name: Publish image
+  #       run: |
+  #         docker load < "image-pharus-${PHARUS_VERSION}-py${PY_VER}-${DISTRO}.tar.gz"
+  #         IMAGE=$(docker images --filter "reference=datajoint/*" --format "{{.Repository}}")
+  #         TAG=$(docker images --filter "reference=datajoint/*" --format "{{.Tag}}")
+  #         docker push "${IMAGE}:${TAG}"
+  #         docker tag "${IMAGE}:${TAG}" "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
+  #         docker push "${IMAGE}:${TAG}-${GITHUB_SHA:0:7}"
+  #         [ "$PY_VER" == "3.8" ] && [ "$DISTRO" == "alpine" ] \
+  #                 && docker tag "${IMAGE}:${TAG}" "${IMAGE}:latest" \
+  #                 && docker push "${IMAGE}:latest" \
+  #             || echo "skipping 'latest' tag..."
+  #     - name: Upload image to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #       with:
+  #         upload_url: ${{needs.publish-release.outputs.release_upload_url}}
+  #         asset_path: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
+  #           ${{matrix.distro}}.tar.gz"
+  #         asset_name: "image-pharus-${{env.PHARUS_VERSION}}-py${{matrix.py_ver}}-\
+  #           ${{matrix.distro}}.tar.gz"
+  #         asset_content_type: application/gzip
+  # publish-docs:
+  #   if: github.event_name == 'push'
+  #   needs: publish-release
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Determine package version
+  #       run: |
+  #         PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}')
+  #         echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
+  #     - name: Fetch docs static artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: docs-static-pharus-${{env.PHARUS_VERSION}}
+  #         path: docs/_build/html
+  #     - name: Commit documentation changes
+  #       run: |
+  #         git clone https://github.com/${GITHUB_REPOSITORY}.git \
+  #             --branch gh-pages --single-branch gh-pages
+  #         rm -R gh-pages/*
+  #         cp -r docs/_build/html/* gh-pages/
+  #         cp .gitignore gh-pages/
+  #         touch gh-pages/.nojekyll
+  #         cd gh-pages
+  #         git config --local user.email "action@github.com"
+  #         git config --local user.name "GitHub Action"
+  #         git add . --all
+  #         git commit -m "Update documentation" -a || true
+  #         # The above command will fail if no changes were present, so we ignore
+  #         # the return code.
+  #     - name: Push changes
+  #       uses: ad-m/github-push-action@master
+  #       with:
+  #         branch: gh-pages
+  #         directory: gh-pages
+  #         github_token: ${{secrets.GITHUB_TOKEN}}
+  #     - name: Compress docs static site artifacts
+  #       run: zip -r docs-static-pharus-${PHARUS_VERSION}.zip docs/_build/html
+  #     - name: Upload docs static site to release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #       with:
+  #         upload_url: ${{needs.publish-release.outputs.release_upload_url}}
+  #         asset_path: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
+  #         asset_name: "docs-static-pharus-${{env.PHARUS_VERSION}}.zip"
+  #         asset_content_type: application/zip
+  #         # fail_on_unmatched_files: true

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -1,4 +1,4 @@
-# PY_VER=3.8 IMAGE=djbase DISTRO=alpine PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-build.yaml up --exit-code-from pharus --build
+# PY_VER=3.8 IMAGE=djbase DISTRO=alpine PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-build.yaml up --exit-code-from pharus --build
 #
 # Intended for updating dependencies and docker image.
 # Used to build release artifacts.

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -8,9 +8,10 @@
 # With this config and the configuration below in NGINX, you should be able to verify it is
 # running properly with a `curl https://fakeservices.datajoint.io/api/version`.
 version: "2.4"
-x-net: &net
+x-net:
+  &net
   networks:
-      - main
+    - main
 services:
   pharus:
     <<: *net

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,4 +1,4 @@
-# PY_VER=3.8 IMAGE=djbase DISTRO=alpine PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-dev.yaml up
+# PY_VER=3.8 IMAGE=djbase DISTRO=alpine PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-dev.yaml up
 #
 # Intended for normal development. Supports hot/live reloading.
 # Note: If requirements or Dockerfile change, will need to add --build flag to docker-compose.
@@ -7,9 +7,10 @@
 # With this config and the configuration below in NGINX, you should be able to verify it is
 # running properly with a `curl https://fakeservices.datajoint.io/api/version`.
 version: "2.4"
-x-net: &net
+x-net:
+  &net
   networks:
-      - main
+    - main
 services:
   local-db:
     <<: *net

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -40,7 +40,7 @@ services:
           echo "------ UNIT TESTS ------"
           pytest -sv --cov-report term-missing --cov=pharus /main/tests
           echo "------ STYLE TESTS ------"
-          flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
+          black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,11 +1,12 @@
-# PY_VER=3.8 IMAGE=djtest DISTRO=alpine AS_SCRIPT=FALSE PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
+# PY_VER=3.8 IMAGE=djtest DISTRO=alpine AS_SCRIPT=FALSE PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\" '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
 #
 # Intended for running test suite locally.
 # Note: If requirements or Dockerfile change, will need to add --build flag.
 version: "2.4"
-x-net: &net
+x-net:
+  &net
   networks:
-      - main
+    - main
 services:
   db:
     <<: *net

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -40,7 +40,7 @@ services:
           echo "------ UNIT TESTS ------"
           pytest -sv --cov-report term-missing --cov=pharus /main/tests
           echo "------ STYLE TESTS ------"
-          black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"
+          black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$$"
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -40,7 +40,7 @@ services:
           echo "------ UNIT TESTS ------"
           pytest -sv --cov-report term-missing --cov=pharus /main/tests
           echo "------ STYLE TESTS ------"
-          flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=95 --statistics --exclude=*dynamic_api.py
+          flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,14 +12,15 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'Pharus'
-copyright = '2021, DataJoint Contributors'
-author = 'DataJoint Contributors'
+project = "Pharus"
+copyright = "2021, DataJoint Contributors"
+author = "DataJoint Contributors"
 
 
 # -- General configuration ---------------------------------------------------
@@ -27,15 +28,15 @@ author = 'DataJoint Contributors'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.httpdomain']
+extensions = ["sphinx.ext.autodoc", "sphinxcontrib.httpdomain"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -43,9 +44,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -45,7 +45,7 @@ Run Tests for Development w/ Pytest and Flake8
 
 - For syntax tests, run ``flake8 ${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics``
 - For pytest integration tests, run ``pytest -sv --cov-report term-missing --cov=${PKG_DIR} /main/tests``
-- For style tests, run ``flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=95 --statistics``
+- For style tests, run ``flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics``
 
 Creating Sphinx Documentation from Scratch
 ------------------------------------------

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -31,8 +31,8 @@ Run Locally w/ Python
 - For development, use CLI command ``pharus``. This method supports hot-reloading so probably best coupled with ``pip install -e ...``.
 - For production, use ``gunicorn --bind 0.0.0.0:${PHARUS_PORT} pharus.server:app``.
 
-Run Tests for Development w/ Pytest and Flake8
-----------------------------------------------
+Run Tests for Development w/ Pytest, Flake8, Black
+--------------------------------------------------
 
 - Set ``pharus`` testing environment variables:
 
@@ -45,7 +45,7 @@ Run Tests for Development w/ Pytest and Flake8
 
 - For syntax tests, run ``flake8 ${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics``
 - For pytest integration tests, run ``pytest -sv --cov-report term-missing --cov=${PKG_DIR} /main/tests``
-- For style tests, run ``flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics``
+- For style tests, run ``black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"``
 
 Creating Sphinx Documentation from Scratch
 ------------------------------------------

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -54,7 +54,9 @@ class _DJConnector:
             for row in dj.conn().query(
                 """
                 SELECT SCHEMA_NAME FROM information_schema.schemata
-                WHERE SCHEMA_NAME NOT IN ("information_schema", "sys", "performance_schema", "mysql")
+                WHERE SCHEMA_NAME NOT IN (
+                    "information_schema", "sys", "performance_schema", "mysql"
+                )
                 ORDER BY SCHEMA_NAME
                 """
             )

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -994,7 +994,8 @@ def dependency(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
             .. sourcecode:: http
 
                 GET /schema/alpha_company/table/Computer/dependency?restriction=W3siYXR0cml"""
-        "idXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3BlcmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo="
+        "idXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3BlcmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo"
+        "="
         """ HTTP/1.1
                 Host: fakeservices.datajoint.io
                 Authorization: Bearer <token>

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -349,14 +349,15 @@ def record(
         """
         Handler for ``/schema/{schema_name}/table/{table_name}/record`` route.
 
-        :param jwt_payload: Dictionary containing databaseAddress, username, and password strings.
+        :param jwt_payload: Dictionary containing databaseAddress, username, and password
+            strings.
         :type jwt_payload: dict
         :param schema_name: Schema name.
         :type schema_name: str
         :param table_name: Table name.
         :type table_name: str
-        :return: If successful performs desired operation based on HTTP method, otherwise returns
-            error.
+        :return: If successful performs desired operation based on HTTP method, otherwise
+            returns error.
         :rtype: :class:`~typing.Union[dict, str, tuple]`
 
         .. http:get:: /schema/{schema_name}/table/{table_name}/record
@@ -368,8 +369,8 @@ def record(
             .. sourcecode:: http
 
                 GET /schema/alpha_company/table/Computer/record?limit=1&page=2&"""
-        "order=computer_id%20DESC&restriction=W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLC"
-        "Aib3BlcmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo="
+        "order=computer_id%20DESC&restriction=W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnk"
+        "iLCAib3BlcmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo="
         """ HTTP/1.1
                 Host: fakeservices.datajoint.io
                 Authorization: Bearer <token>
@@ -424,23 +425,24 @@ def record(
                 Vary: Accept
                 Content-Type: text/plain
 
-                400 Bad Request: The browser (or proxy) sent a request that this server could not
-                    understand.
+                400 Bad Request: The browser (or proxy) sent a request that this server could
+                    not understand.
 
             :query schema_name: Schema name.
             :query table_name: Table name.
             :query limit: Limit of how many records per page. Defaults to ``1000``.
             :query page: Page requested. Defaults to ``1``.
             :query order: Sort order. Defaults to ``KEY ASC``.
-            :query restriction: Base64-encoded ``AND`` sequence of restrictions. For example, you
-                could restrict as ``[{"attributeName": "computer_memory", "operation": ">=",``-
-                ``"value": 16}]`` with this param set as
+            :query restriction: Base64-encoded ``AND`` sequence of restrictions. For example,
+                you could restrict as ``[{"attributeName": "computer_memory", "operation": ``-
+                ``">=", "value": 16}]`` with this param set as
                 ``W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3Bl``-
                 ``cmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo=``. Defaults to no restriction.
             :reqheader Authorization: Bearer <OAuth2_token>
             :resheader Content-Type: text/plain, application/json
             :statuscode 200: No error.
-            :statuscode 500: Unexpected error encountered. Returns the error message as a string.
+            :statuscode 500: Unexpected error encountered. Returns the error message as a
+                string.
 
         .. http:post:: /schema/{schema_name}/table/{table_name}/record
 
@@ -491,13 +493,14 @@ def record(
                 Vary: Accept
                 Content-Type: text/plain
 
-                400 Bad Request: The browser (or proxy) sent a request that this server could not
-                    understand.
+                400 Bad Request: The browser (or proxy) sent a request that this server could
+                    not understand.
 
             :reqheader Authorization: Bearer <OAuth2_token>
             :resheader Content-Type: text/plain
             :statuscode 200: No error.
-            :statuscode 500: Unexpected error encountered. Returns the error message as a string.
+            :statuscode 500: Unexpected error encountered. Returns the error message as a
+                string.
 
         .. http:patch:: /schema/{schema_name}/table/{table_name}/record
 
@@ -548,13 +551,14 @@ def record(
                 Vary: Accept
                 Content-Type: text/plain
 
-                400 Bad Request: The browser (or proxy) sent a request that this server could not
-                    understand.
+                400 Bad Request: The browser (or proxy) sent a request that this server could
+                    not understand.
 
             :reqheader Authorization: Bearer <OAuth2_token>
             :resheader Content-Type: text/plain
             :statuscode 200: No error.
-            :statuscode 500: Unexpected error encountered. Returns the error message as a string.
+            :statuscode 500: Unexpected error encountered. Returns the error message as a
+                string.
 
         .. http:delete:: /schema/{schema_name}/table/{table_name}/record
 
@@ -565,8 +569,8 @@ def record(
             .. sourcecode:: http
 
                 DELETE /schema/alpha_company/table/Computer/record?cascade=false&"""
-        "restriction=W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3BlcmF0aW9uIjogIj49Iiw"
-        "gInZhbHVlIjogMTZ9XQo="
+        "restriction=W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3BlcmF0aW9uIjogIj49"
+        "IiwgInZhbHVlIjogMTZ9XQo="
         """ HTTP/1.1
                 Host: fakeservices.datajoint.io
                 Authorization: Bearer <token>
@@ -591,10 +595,10 @@ def record(
 
                 {
                     "error": "IntegrityError",
-                    "error_msg": "Cannot delete or update a parent row: a foreign key constraint
-                        fails (`alpha_company`.`#employee`, CONSTRAINT `#employee_ibfk_1` FOREIGN
-                        KEY (`computer_id`) REFERENCES `computer` (`computer_id`) ON DELETE
-                        RESTRICT ON UPDATE CASCADE",
+                    "error_msg": "Cannot delete or update a parent row: a foreign key
+                        constraint fails (`alpha_company`.`#employee`, CONSTRAINT
+                        `#employee_ibfk_1` FOREIGN KEY (`computer_id`) REFERENCES `computer`
+                        (`computer_id`) ON DELETE RESTRICT ON UPDATE CASCADE",
                     "child_schema": "alpha_company",
                     "child_table": "Employee"
                 }
@@ -607,22 +611,23 @@ def record(
                 Vary: Accept
                 Content-Type: text/plain
 
-                400 Bad Request: The browser (or proxy) sent a request that this server could not
-                    understand.
+                400 Bad Request: The browser (or proxy) sent a request that this server could
+                    not understand.
 
             :query cascade: Enable cascading delete. Accepts ``true`` or ``false``.
                 Defaults to ``false``.
-            :query restriction: Base64-encoded ``AND`` sequence of restrictions. For example, you
-                could restrict as ``[{"attributeName": "computer_memory", "operation": ">=",``-
-                ``"value": 16}]`` with this param set as
+            :query restriction: Base64-encoded ``AND`` sequence of restrictions. For example,
+                you could restrict as ``[{"attributeName": "computer_memory", "operation": ``-
+                ``">=", "value": 16}]`` with this param set as
                 ``W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3Bl``-
                 ``cmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo=``. Defaults to no restriction.
             :reqheader Authorization: Bearer <OAuth2_token>
             :resheader Content-Type: text/plain, application/json
             :statuscode 200: No error.
-            :statuscode 409: Attempting to delete a record with dependents while ``cascade`` set
-                to ``false``.
-            :statuscode 500: Unexpected error encountered. Returns the error message as a string.
+            :statuscode 409: Attempting to delete a record with dependents while ``cascade``
+                set to ``false``.
+            :statuscode 500: Unexpected error encountered. Returns the error message as a
+                string.
         """
     )
     if request.method in {"GET", "HEAD"}:
@@ -969,7 +974,8 @@ def dependency(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
         """
         Handler for ``/schema/{schema_name}/table/{table_name}/dependency`` route.
 
-        :param jwt_payload: Dictionary containing databaseAddress, username, and password strings.
+        :param jwt_payload: Dictionary containing databaseAddress, username, and password
+            strings.
         :type jwt_payload: dict
         :param schema_name: Schema name.
         :type schema_name: str
@@ -980,15 +986,15 @@ def dependency(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
 
         .. http:get:: /schema/{schema_name}/table/{table_name}/dependency
 
-            Route to get the metadata in relation to the dependent records associated with a """
-        """restricted subset of a table.
+            Route to get the metadata in relation to the dependent records associated with """
+        """a restricted subset of a table.
 
             **Example request**:
 
             .. sourcecode:: http
 
-                GET /schema/alpha_company/table/Computer/dependency?restriction=W3siYXR0cmlidXR"""
-        "lTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3BlcmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo="
+                GET /schema/alpha_company/table/Computer/dependency?restriction=W3siYXR0cml"""
+        "idXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3BlcmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo="
         """ HTTP/1.1
                 Host: fakeservices.datajoint.io
                 Authorization: Bearer <token>
@@ -1026,20 +1032,21 @@ def dependency(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
                 Vary: Accept
                 Content-Type: text/plain
 
-                400 Bad Request: The browser (or proxy) sent a request that this server could not
-                    understand.
+                400 Bad Request: The browser (or proxy) sent a request that this server could
+                    not understand.
 
             :query schema_name: Schema name.
             :query table_name: Table name.
-            :query restriction: Base64-encoded ``AND`` sequence of restrictions. For example, you
-                could restrict as ``[{"attributeName": "computer_memory", "operation": ">=",``-
-                ``"value": 16}]`` with this param set as
+            :query restriction: Base64-encoded ``AND`` sequence of restrictions. For example,
+                you could restrict as ``[{"attributeName": "computer_memory", "operation": ``-
+                ``">=", "value": 16}]`` with this param set as
                 ``W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3Bl``-
                 ``cmF0aW9uIjogIj49IiwgInZhbHVlIjogMTZ9XQo=``. Defaults to no restriction.
             :reqheader Authorization: Bearer <OAuth2_token>
             :resheader Content-Type: text/plain, application/json
             :statuscode 200: No error.
-            :statuscode 500: Unexpected error encountered. Returns the error message as a string.
+            :statuscode 500: Unexpected error encountered. Returns the error message as a
+                string.
         """
     )
     if request.method in {"GET", "HEAD"}:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 flake8
 Faker
+black


### PR DESCRIPTION
- Fix `version.py` parsing since `black` switched to `"` delimiter
- Optimize GH Actions to run on push in forks but only on tags in base
- Change style tests to `black`
- Update docs on tests
- *Blacken* `conf.py` in docs
- Fix multiline strings' length to 94 characters (multiline strings are largely ignored by `black`)