### PR TITLE
Readd `flake8` to style tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.2.4] - TBA
+## [0.3.0] - TBA
 ### Changed
 - Hot-reload mechanism to use `otumat watch` PR #116
 - Renamed environment variable defining spec sheet to `PHARUS_SPEC_PATH` PR #116
@@ -97,7 +97,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Support for DataJoint attribute types: `varchar`, `int`, `float`, `datetime`, `date`, `time`, `decimal`, `uuid`.
 - Check dependency utility to determine child table references.
 
-[0.2.4]: https://github.com/datajoint/pharus/compare/0.2.3...0.2.4
+[0.3.0]: https://github.com/datajoint/pharus/compare/0.2.3...0.3.0
 [0.2.3]: https://github.com/datajoint/pharus/compare/0.2.2...0.2.3
 [0.2.2]: https://github.com/datajoint/pharus/compare/0.2.1...0.2.2
 [0.2.1]: https://github.com/datajoint/pharus/compare/0.2.0...0.2.1

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -37,11 +37,14 @@ services:
           echo "------ SYNTAX TESTS ------"
           PKG_DIR=/opt/conda/lib/python3.8/site-packages/pharus
           flake8 $${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 /main/tests --count --select=E9,F63,F7,F82 --show-source --statistics
           echo "------ UNIT TESTS ------"
           pytest -sv --cov-report term-missing --cov=pharus /main/tests
           echo "------ STYLE TESTS ------"
           black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$$"
           flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
+          black /main/tests --check -v
+          flake8 /main/tests --count --max-complexity=20 --max-line-length=94 --statistics
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -42,9 +42,9 @@ services:
           pytest -sv --cov-report term-missing --cov=pharus /main/tests
           echo "------ STYLE TESTS ------"
           black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$$"
-          flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
+          flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py --ignore=W503
           black /main/tests --check -v
-          flake8 /main/tests --count --max-complexity=20 --max-line-length=94 --statistics
+          flake8 /main/tests --count --max-complexity=20 --max-line-length=94 --statistics --ignore=F401,F811,W503
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -41,6 +41,7 @@ services:
           pytest -sv --cov-report term-missing --cov=pharus /main/tests
           echo "------ STYLE TESTS ------"
           black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$$"
+          flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -46,10 +46,11 @@ Run Tests for Development w/ Pytest, Flake8, Black
 - For syntax tests, run ``flake8 ${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics``
 - For pytest integration tests, run ``pytest -sv --cov-report term-missing --cov=${PKG_DIR} /main/tests``
 - For style tests, run:
-  ```shell
-  black ${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"
-  flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
-  ```
+
+    .. code-block:: bash
+
+        black ${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"
+        flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
 
 Creating Sphinx Documentation from Scratch
 ------------------------------------------

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -45,7 +45,11 @@ Run Tests for Development w/ Pytest, Flake8, Black
 
 - For syntax tests, run ``flake8 ${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics``
 - For pytest integration tests, run ``pytest -sv --cov-report term-missing --cov=${PKG_DIR} /main/tests``
-- For style tests, run ``black $${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"``
+- For style tests, run:
+  ```shell
+  black ${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"
+  flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
+  ```
 
 Creating Sphinx Documentation from Scratch
 ------------------------------------------

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -50,7 +50,7 @@ Run Tests for Development w/ Pytest, Flake8, Black
     .. code-block:: bash
 
         black ${PKG_DIR} --check -v --extend-exclude "^.*dynamic_api.py$"
-        flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py
+        flake8 ${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py --ignore=W503
 
 Creating Sphinx Documentation from Scratch
 ------------------------------------------

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.2.4"
+__version__ = "0.3.0"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,5 +1,4 @@
 from . import (
-    SCHEMA_PREFIX,
     client,
     token,
     connection,


### PR DESCRIPTION
- Readd since `flake8` does more than just formatting and `black` is strictly just for code [formatting](https://github.com/psf/black/issues/86).
- Apparently `W503` is [not PEP8 compliant](https://github.com/psf/black/issues/52). Removing from style tests.
- Noticed that our syntax/style tests aren't running against our `tests` module. Included it now.
- Apparently, there is some issue around running style tests with pytest fixtures. Disabling `F401` and `F811` for now but the solution maybe to work with the [conftest.py](https://stackoverflow.com/questions/43746413/how-do-i-get-flake8-to-work-with-f811-errors) file in the future.
- Update docs
- Bump version due to changelog

